### PR TITLE
ci: github workflow and carbon launcher support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+
+env:
+  SOLUTION_FILE_PATH: .
+  BUILD_CONFIGURATION: Release
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup VCPKG
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgGitCommitId: aafb8b71554a4590aa5108bdb5005d81d72db6c1
+
+    - name: Integrate vcpkg
+      run: vcpkg integrate install
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Mod_${{env.BUILD_CONFIGURATION}}
+        path: |
+          Build\x64\${{env.BUILD_CONFIGURATION}}\NetworkChecksumDisabler.dll
+
+    - name: Create Release
+      uses: ncipollo/release-action@v1.14.0
+      with:
+        artifacts: Build\x64\${{env.BUILD_CONFIGURATION}}\NetworkChecksumDisabler.dll
+        draft: false
+        makeLatest: true

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/ScrappySM/CarbonLauncher/refs/heads/main/schema.json",
+
+  "name": "Network Checksum Disabler",
+  "url": "https://github.com/ReDoIngMods/Network-Checksum-Disabler",
+
+  "authors": [
+    "crackx02"
+  ],
+
+  "description": "Disables the multiplayer game files checksum in Scrap Mechanic"
+}


### PR DESCRIPTION
Hey there, I maintain Carbon Launcher which is a mod launcher for Scrap Mechanic (specifically DLL mods currently) and I am trying to centralise the way this works (whether it be through Carbon Launcher or not) by attempting to create standards.

You can see Carbon Launcher here supporting your mod (using my fork of this repo which I will change to the official repo if this PR is accepted)
![image](https://github.com/user-attachments/assets/de2c483a-9317-415a-b2e8-57cc7b7ad47c)

Your mod is currently available on the public mods section of Carbon Launcher using my fork.

I would love it if we could try to formulate some kind of universal standard for DLL modding and some repository of mods (which I am attempting with [repos.json](https://github.com/ScrappySM/CarbonLauncher/blob/main/repos.json) which will most likely be reworked into a real solution at some point.

The GitHub workflow allows for testing in the CI/CD and when combined with a `manifest.json` can support Carbon Launcher mod loader which can be found [here](https://github.com/ScrappySM/CarbonLauncher)

Thanks!